### PR TITLE
chore: integrate jsc into example on android

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -48,6 +48,7 @@ target_include_directories(
   "${COMMON_DIR}"
   "${REACT_NATIVE_DIR}/ReactCommon"
   "${REACT_NATIVE_DIR}/ReactCommon/jsiexecutor"
+  "${REACT_NATIVE_DIR}/ReactCommon/jsitooling"
   "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni"
 )
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -63,14 +63,14 @@ def enableProguardInReleaseBuilds = false
  * The preferred build flavor of JavaScriptCore (JSC)
  *
  * For example, to use the international variant, you can use:
- * `def jscFlavor = 'org.webkit:android-jsc-intl:+'`
+ * `def jscFlavor = 'io.github.react-native-community:jsc-android-intl:2026004.+'`
  *
  * The international variant includes ICU i18n library and necessary data
  * allowing to use e.g. `Date.toLocaleString` and `String.localeCompare` that
  * give correct results when using with locales other than en-US. Note that
  * this variant is about 6MiB larger per architecture than default.
  */
-def jscFlavor = 'org.webkit:android-jsc:+'
+def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
 android {
     ndkVersion rootProject.ext.ndkVersion

--- a/example/android/app/src/main/java/com/jscexample/MainApplication.kt
+++ b/example/android/app/src/main/java/com/jscexample/MainApplication.kt
@@ -6,11 +6,15 @@ import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.JavaScriptExecutorFactory
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
+import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
+import io.github.reactnativecommunity.javascriptcore.JSCExecutorFactory
+import io.github.reactnativecommunity.javascriptcore.JSCRuntimeFactory
 
 class MainApplication : Application(), ReactApplication {
 
@@ -28,10 +32,13 @@ class MainApplication : Application(), ReactApplication {
 
         override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+
+        override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory =
+          JSCExecutorFactory(packageName, AndroidInfoHelpers.getFriendlyDeviceName())
       }
 
   override val reactHost: ReactHost
-    get() = getDefaultReactHost(applicationContext, reactNativeHost)
+    get() = getDefaultReactHost(applicationContext, reactNativeHost, JSCRuntimeFactory())
 
   override fun onCreate() {
     super.onCreate()

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -36,4 +36,6 @@ newArchEnabled=true
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
-hermesEnabled=true
+hermesEnabled=false
+
+useThirdPartyJSC=true


### PR DESCRIPTION
the other option for #3 that will ultimately pull change in core

- add `react-native.config.js` for autolinking
- build react-native from source and add patch-packages the two changes:
  - https://github.com/facebook/react-native/pull/49365
  - https://github.com/facebook/react-native/pull/49366
- add `useThirdPartyJSC=true`
- [old arch] overwrites `MainApplication.getJavaScriptExecutorFactory()` to use `JSCExecutorFactory`
- [new arch] pass `JSCRuntimeFactory` to the `getDefaultReactHost(applicationContext, reactNativeHost, JSCRuntimeFactory())`