### PR TITLE
feat: use JSITooling package

### DIFF
--- a/React-jsc.podspec
+++ b/React-jsc.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
 
   s.dependency "RCT-Folly", folly_version
   s.dependency "DoubleConversion"
-  # s.dependency "React-jsitooling" Uncomment once merged in React Native
+  s.dependency "React-jsitooling"
   s.dependency "React-cxxreact"
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -8,6 +8,9 @@ require Pod::Executable.execute_command('node', ['-p',
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
+# Disable linking of internal JSC
+ENV['USE_THIRD_PARTY_JSC'] = '1'
+
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil
   Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
-  - FBLazyVector (0.79.0-nightly-20250213-9a401c810)
+  - FBLazyVector (0.79.0-nightly-20250218-cda2d11c1)
   - fmt (11.0.2)
   - glog (0.3.5)
   - RCT-Folly (2024.11.18.00):
@@ -24,34 +24,33 @@ PODS:
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.79.0-nightly-20250213-9a401c810)
-  - RCTRequired (0.79.0-nightly-20250213-9a401c810)
-  - RCTTypeSafety (0.79.0-nightly-20250213-9a401c810):
-    - FBLazyVector (= 0.79.0-nightly-20250213-9a401c810)
-    - RCTRequired (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Core (= 0.79.0-nightly-20250213-9a401c810)
-  - React (0.79.0-nightly-20250213-9a401c810):
-    - React-Core (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Core/DevSupport (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Core/RCTWebSocket (= 0.79.0-nightly-20250213-9a401c810)
-    - React-RCTActionSheet (= 0.79.0-nightly-20250213-9a401c810)
-    - React-RCTAnimation (= 0.79.0-nightly-20250213-9a401c810)
-    - React-RCTBlob (= 0.79.0-nightly-20250213-9a401c810)
-    - React-RCTImage (= 0.79.0-nightly-20250213-9a401c810)
-    - React-RCTLinking (= 0.79.0-nightly-20250213-9a401c810)
-    - React-RCTNetwork (= 0.79.0-nightly-20250213-9a401c810)
-    - React-RCTSettings (= 0.79.0-nightly-20250213-9a401c810)
-    - React-RCTText (= 0.79.0-nightly-20250213-9a401c810)
-    - React-RCTVibration (= 0.79.0-nightly-20250213-9a401c810)
-  - React-callinvoker (0.79.0-nightly-20250213-9a401c810)
-  - React-Core (0.79.0-nightly-20250213-9a401c810):
+  - RCTDeprecation (0.79.0-nightly-20250218-cda2d11c1)
+  - RCTRequired (0.79.0-nightly-20250218-cda2d11c1)
+  - RCTTypeSafety (0.79.0-nightly-20250218-cda2d11c1):
+    - FBLazyVector (= 0.79.0-nightly-20250218-cda2d11c1)
+    - RCTRequired (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Core (= 0.79.0-nightly-20250218-cda2d11c1)
+  - React (0.79.0-nightly-20250218-cda2d11c1):
+    - React-Core (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Core/DevSupport (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Core/RCTWebSocket (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-RCTActionSheet (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-RCTAnimation (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-RCTBlob (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-RCTImage (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-RCTLinking (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-RCTNetwork (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-RCTSettings (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-RCTText (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-RCTVibration (= 0.79.0-nightly-20250218-cda2d11c1)
+  - React-callinvoker (0.79.0-nightly-20250218-cda2d11c1)
+  - React-Core (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.79.0-nightly-20250213-9a401c810)
+    - React-Core/Default (= 0.79.0-nightly-20250218-cda2d11c1)
     - React-cxxreact
     - React-featureflags
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
@@ -60,62 +59,13 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.79.0-nightly-20250213-9a401c810):
-    - glog
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/Default (0.79.0-nightly-20250213-9a401c810):
-    - glog
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/DevSupport (0.79.0-nightly-20250213-9a401c810):
-    - glog
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-Core/Default (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Core/RCTWebSocket (= 0.79.0-nightly-20250213-9a401c810)
-    - React-cxxreact
-    - React-featureflags
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.79.0-nightly-20250213-9a401c810):
+  - React-Core/CoreModulesHeaders (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
@@ -124,14 +74,43 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.79.0-nightly-20250213-9a401c810):
+  - React-Core/Default (0.79.0-nightly-20250218-cda2d11c1):
+    - glog
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/DevSupport (0.79.0-nightly-20250218-cda2d11c1):
+    - glog
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Core/RCTWebSocket (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-cxxreact
+    - React-featureflags
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
@@ -140,14 +119,13 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.79.0-nightly-20250213-9a401c810):
+  - React-Core/RCTAnimationHeaders (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
@@ -156,14 +134,13 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.79.0-nightly-20250213-9a401c810):
+  - React-Core/RCTBlobHeaders (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
@@ -172,14 +149,13 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.79.0-nightly-20250213-9a401c810):
+  - React-Core/RCTImageHeaders (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
@@ -188,14 +164,13 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.79.0-nightly-20250213-9a401c810):
+  - React-Core/RCTLinkingHeaders (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
@@ -204,14 +179,13 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.79.0-nightly-20250213-9a401c810):
+  - React-Core/RCTNetworkHeaders (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
@@ -220,14 +194,13 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.79.0-nightly-20250213-9a401c810):
+  - React-Core/RCTSettingsHeaders (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
@@ -236,14 +209,13 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.79.0-nightly-20250213-9a401c810):
+  - React-Core/RCTTextHeaders (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
     - React-Core/Default
     - React-cxxreact
     - React-featureflags
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
@@ -252,14 +224,13 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.79.0-nightly-20250213-9a401c810):
+  - React-Core/RCTVibrationHeaders (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.79.0-nightly-20250213-9a401c810)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
@@ -268,59 +239,72 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-CoreModules (0.79.0-nightly-20250213-9a401c810):
+  - React-Core/RCTWebSocket (0.79.0-nightly-20250218-cda2d11c1):
+    - glog
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-cxxreact
+    - React-featureflags
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-CoreModules (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - RCT-Folly (= 2024.11.18.00)
-    - RCTTypeSafety (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Core/CoreModulesHeaders (= 0.79.0-nightly-20250213-9a401c810)
-    - React-jsi (= 0.79.0-nightly-20250213-9a401c810)
+    - RCTTypeSafety (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Core/CoreModulesHeaders (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-jsi (= 0.79.0-nightly-20250218-cda2d11c1)
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.79.0-nightly-20250213-9a401c810)
+    - React-RCTImage (= 0.79.0-nightly-20250218-cda2d11c1)
     - ReactCommon
     - SocketRocket (= 0.7.1)
-  - React-cxxreact (0.79.0-nightly-20250213-9a401c810):
+  - React-cxxreact (0.79.0-nightly-20250218-cda2d11c1):
     - boost
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-nightly-20250213-9a401c810)
-    - React-debug (= 0.79.0-nightly-20250213-9a401c810)
-    - React-jsi (= 0.79.0-nightly-20250213-9a401c810)
+    - React-callinvoker (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-debug (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-jsi (= 0.79.0-nightly-20250218-cda2d11c1)
     - React-jsinspector
-    - React-logger (= 0.79.0-nightly-20250213-9a401c810)
-    - React-perflogger (= 0.79.0-nightly-20250213-9a401c810)
-    - React-runtimeexecutor (= 0.79.0-nightly-20250213-9a401c810)
-    - React-timing (= 0.79.0-nightly-20250213-9a401c810)
-  - React-debug (0.79.0-nightly-20250213-9a401c810)
-  - React-defaultsnativemodule (0.79.0-nightly-20250213-9a401c810):
+    - React-logger (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-perflogger (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-runtimeexecutor (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-timing (= 0.79.0-nightly-20250218-cda2d11c1)
+  - React-debug (0.79.0-nightly-20250218-cda2d11c1)
+  - React-defaultsnativemodule (0.79.0-nightly-20250218-cda2d11c1):
     - RCT-Folly
     - React-domnativemodule
     - React-featureflagsnativemodule
     - React-idlecallbacksnativemodule
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
-  - React-domnativemodule (0.79.0-nightly-20250213-9a401c810):
+  - React-domnativemodule (0.79.0-nightly-20250218-cda2d11c1):
     - RCT-Folly
     - React-Fabric
     - React-FabricComponents
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -331,25 +315,24 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/attributedstring (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/componentregistry (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/componentregistrynative (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/components (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/consistency (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/core (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/dom (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/imagemanager (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/leakchecker (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/mounting (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/observers (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/scheduler (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/telemetry (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/templateprocessor (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/uimanager (= 0.79.0-nightly-20250213-9a401c810)
+    - React-Fabric/animations (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/attributedstring (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/componentregistry (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/componentregistrynative (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/components (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/consistency (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/core (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/dom (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/imagemanager (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/leakchecker (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/mounting (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/observers (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/scheduler (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/telemetry (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/templateprocessor (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/uimanager (= 0.79.0-nightly-20250218-cda2d11c1)
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -357,7 +340,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/animations (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -370,7 +353,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -378,7 +360,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/attributedstring (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -391,7 +373,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -399,7 +380,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/componentregistry (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -412,7 +393,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -420,7 +400,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/componentregistrynative (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -433,7 +413,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -441,7 +420,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/components (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -452,13 +431,12 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/components/root (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/components/scrollview (= 0.79.0-nightly-20250213-9a401c810)
-    - React-Fabric/components/view (= 0.79.0-nightly-20250213-9a401c810)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/components/root (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/components/scrollview (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-Fabric/components/view (= 0.79.0-nightly-20250218-cda2d11c1)
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -466,7 +444,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/components/legacyviewmanagerinterop (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -479,7 +457,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -487,7 +464,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/components/root (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -500,7 +477,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -508,7 +484,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/scrollview (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/components/scrollview (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -521,7 +497,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -529,7 +504,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/components/view (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -542,7 +517,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -552,7 +526,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/consistency (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/consistency (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -565,7 +539,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -573,7 +546,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/core (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/core (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -586,7 +559,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -594,7 +566,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/dom (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/dom (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -607,7 +579,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -615,7 +586,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/imagemanager (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -628,7 +599,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -636,7 +606,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/leakchecker (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -649,7 +619,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -657,7 +626,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/mounting (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -670,7 +639,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -678,7 +646,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/observers (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -689,10 +657,9 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.79.0-nightly-20250213-9a401c810)
+    - React-Fabric/observers/events (= 0.79.0-nightly-20250218-cda2d11c1)
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -700,7 +667,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers/events (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/observers/events (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -713,7 +680,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -721,7 +687,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/scheduler (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -735,7 +701,6 @@ PODS:
     - React-Fabric/observers/events
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -744,7 +709,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/telemetry (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -757,7 +722,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -765,7 +729,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/templateprocessor (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -778,7 +742,6 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -786,7 +749,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/uimanager (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -797,32 +760,9 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.79.0-nightly-20250213-9a401c810)
+    - React-Fabric/uimanager/consistency (= 0.79.0-nightly-20250218-cda2d11c1)
     - React-featureflags
     - React-graphics
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager/consistency (0.79.0-nightly-20250213-9a401c810):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -831,7 +771,28 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricComponents (0.79.0-nightly-20250213-9a401c810):
+  - React-Fabric/uimanager/consistency (0.79.0-nightly-20250218-cda2d11c1):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-FabricComponents (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -843,11 +804,10 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.79.0-nightly-20250213-9a401c810)
-    - React-FabricComponents/textlayoutmanager (= 0.79.0-nightly-20250213-9a401c810)
+    - React-FabricComponents/components (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-FabricComponents/textlayoutmanager (= 0.79.0-nightly-20250218-cda2d11c1)
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -856,7 +816,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components (0.79.0-nightly-20250213-9a401c810):
+  - React-FabricComponents/components (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -868,18 +828,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.79.0-nightly-20250213-9a401c810)
-    - React-FabricComponents/components/iostextinput (= 0.79.0-nightly-20250213-9a401c810)
-    - React-FabricComponents/components/modal (= 0.79.0-nightly-20250213-9a401c810)
-    - React-FabricComponents/components/rncore (= 0.79.0-nightly-20250213-9a401c810)
-    - React-FabricComponents/components/safeareaview (= 0.79.0-nightly-20250213-9a401c810)
-    - React-FabricComponents/components/scrollview (= 0.79.0-nightly-20250213-9a401c810)
-    - React-FabricComponents/components/text (= 0.79.0-nightly-20250213-9a401c810)
-    - React-FabricComponents/components/textinput (= 0.79.0-nightly-20250213-9a401c810)
-    - React-FabricComponents/components/unimplementedview (= 0.79.0-nightly-20250213-9a401c810)
+    - React-FabricComponents/components/inputaccessory (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-FabricComponents/components/iostextinput (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-FabricComponents/components/modal (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-FabricComponents/components/rncore (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-FabricComponents/components/safeareaview (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-FabricComponents/components/scrollview (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-FabricComponents/components/text (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-FabricComponents/components/textinput (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-FabricComponents/components/unimplementedview (= 0.79.0-nightly-20250218-cda2d11c1)
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -888,53 +847,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.79.0-nightly-20250213-9a401c810):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.79.0-nightly-20250213-9a401c810):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsc
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/modal (0.79.0-nightly-20250213-9a401c810):
+  - React-FabricComponents/components/inputaccessory (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -948,7 +861,6 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -957,7 +869,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/rncore (0.79.0-nightly-20250213-9a401c810):
+  - React-FabricComponents/components/iostextinput (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -971,7 +883,6 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -980,7 +891,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.79.0-nightly-20250213-9a401c810):
+  - React-FabricComponents/components/modal (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -994,7 +905,6 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1003,7 +913,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/scrollview (0.79.0-nightly-20250213-9a401c810):
+  - React-FabricComponents/components/rncore (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1017,7 +927,6 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1026,7 +935,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/text (0.79.0-nightly-20250213-9a401c810):
+  - React-FabricComponents/components/safeareaview (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1040,7 +949,6 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1049,7 +957,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/textinput (0.79.0-nightly-20250213-9a401c810):
+  - React-FabricComponents/components/scrollview (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1063,7 +971,6 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1072,7 +979,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.79.0-nightly-20250213-9a401c810):
+  - React-FabricComponents/components/text (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1086,7 +993,6 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1095,7 +1001,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.79.0-nightly-20250213-9a401c810):
+  - React-FabricComponents/components/textinput (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1109,7 +1015,6 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1118,56 +1023,96 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricImage (0.79.0-nightly-20250213-9a401c810):
+  - React-FabricComponents/components/unimplementedview (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired (= 0.79.0-nightly-20250213-9a401c810)
-    - RCTTypeSafety (= 0.79.0-nightly-20250213-9a401c810)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.79.0-nightly-20250218-cda2d11c1):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricImage (0.79.0-nightly-20250218-cda2d11c1):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired (= 0.79.0-nightly-20250218-cda2d11c1)
+    - RCTTypeSafety (= 0.79.0-nightly-20250218-cda2d11c1)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - React-jsc
     - React-jsi
-    - React-jsiexecutor (= 0.79.0-nightly-20250213-9a401c810)
+    - React-jsiexecutor (= 0.79.0-nightly-20250218-cda2d11c1)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-featureflags (0.79.0-nightly-20250213-9a401c810):
+  - React-featureflags (0.79.0-nightly-20250218-cda2d11c1):
     - RCT-Folly (= 2024.11.18.00)
-  - React-featureflagsnativemodule (0.79.0-nightly-20250213-9a401c810):
+  - React-featureflagsnativemodule (0.79.0-nightly-20250218-cda2d11c1):
     - RCT-Folly
     - React-featureflags
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-  - React-graphics (0.79.0-nightly-20250213-9a401c810):
+  - React-graphics (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - RCT-Folly/Fabric (= 2024.11.18.00)
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-utils
-  - React-idlecallbacksnativemodule (0.79.0-nightly-20250213-9a401c810):
+  - React-idlecallbacksnativemodule (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
-  - React-ImageManager (0.79.0-nightly-20250213-9a401c810):
+  - React-ImageManager (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -1177,27 +1122,13 @@ PODS:
     - React-rendererdebug
     - React-utils
   - React-jsc (0.0.1):
-    - boost
     - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - RCT-Folly (= 2024.11.18.00)
-    - React-cxxreact
-    - React-jsc/Fabric (= 0.0.1)
-    - React-jsi
-    - React-jsiexecutor
-  - React-jsc/Fabric (0.0.1):
-    - boost
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
     - RCT-Folly (= 2024.11.18.00)
     - React-cxxreact
     - React-jsi
     - React-jsiexecutor
-  - React-jserrorhandler (0.79.0-nightly-20250213-9a401c810):
+    - React-jsitooling
+  - React-jserrorhandler (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly/Fabric (= 2024.11.18.00)
     - React-cxxreact
@@ -1205,71 +1136,80 @@ PODS:
     - React-featureflags
     - React-jsi
     - ReactCommon/turbomodule/bridging
-  - React-jsi (0.79.0-nightly-20250213-9a401c810):
+  - React-jsi (0.79.0-nightly-20250218-cda2d11c1):
     - boost
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - RCT-Folly (= 2024.11.18.00)
-  - React-jsiexecutor (0.79.0-nightly-20250213-9a401c810):
+  - React-jsiexecutor (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - RCT-Folly (= 2024.11.18.00)
-    - React-cxxreact (= 0.79.0-nightly-20250213-9a401c810)
-    - React-jsi (= 0.79.0-nightly-20250213-9a401c810)
+    - React-cxxreact (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-jsi (= 0.79.0-nightly-20250218-cda2d11c1)
     - React-jsinspector
-    - React-perflogger (= 0.79.0-nightly-20250213-9a401c810)
-  - React-jsinspector (0.79.0-nightly-20250213-9a401c810):
+    - React-perflogger (= 0.79.0-nightly-20250218-cda2d11c1)
+  - React-jsinspector (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - glog
     - RCT-Folly
     - React-featureflags
     - React-jsi
     - React-jsinspectortracing
-    - React-perflogger (= 0.79.0-nightly-20250213-9a401c810)
-    - React-runtimeexecutor (= 0.79.0-nightly-20250213-9a401c810)
-  - React-jsinspectortracing (0.79.0-nightly-20250213-9a401c810):
+    - React-perflogger (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-runtimeexecutor (= 0.79.0-nightly-20250218-cda2d11c1)
+  - React-jsinspectortracing (0.79.0-nightly-20250218-cda2d11c1):
     - RCT-Folly
-  - React-jsitracing (0.79.0-nightly-20250213-9a401c810):
-    - React-jsi
-  - React-logger (0.79.0-nightly-20250213-9a401c810):
+    - React-oscompat
+  - React-jsitooling (0.79.0-nightly-20250218-cda2d11c1):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
     - glog
-  - React-Mapbuffer (0.79.0-nightly-20250213-9a401c810):
+    - RCT-Folly (= 2024.11.18.00)
+    - React-cxxreact (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-jsi (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-jsinspector
+  - React-jsitracing (0.79.0-nightly-20250218-cda2d11c1):
+    - React-jsi
+  - React-logger (0.79.0-nightly-20250218-cda2d11c1):
+    - glog
+  - React-Mapbuffer (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - React-debug
-  - React-microtasksnativemodule (0.79.0-nightly-20250213-9a401c810):
+  - React-microtasksnativemodule (0.79.0-nightly-20250218-cda2d11c1):
     - RCT-Folly
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-  - React-NativeModulesApple (0.79.0-nightly-20250213-9a401c810):
+  - React-NativeModulesApple (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - React-callinvoker
     - React-Core
     - React-cxxreact
-    - React-jsc
     - React-jsi
     - React-jsinspector
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.79.0-nightly-20250213-9a401c810):
+  - React-oscompat (0.79.0-nightly-20250218-cda2d11c1)
+  - React-perflogger (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - RCT-Folly (= 2024.11.18.00)
-  - React-performancetimeline (0.79.0-nightly-20250213-9a401c810):
+  - React-performancetimeline (0.79.0-nightly-20250218-cda2d11c1):
     - RCT-Folly (= 2024.11.18.00)
     - React-cxxreact
     - React-featureflags
     - React-jsinspectortracing
     - React-timing
-  - React-RCTActionSheet (0.79.0-nightly-20250213-9a401c810):
-    - React-Core/RCTActionSheetHeaders (= 0.79.0-nightly-20250213-9a401c810)
-  - React-RCTAnimation (0.79.0-nightly-20250213-9a401c810):
+  - React-RCTActionSheet (0.79.0-nightly-20250218-cda2d11c1):
+    - React-Core/RCTActionSheetHeaders (= 0.79.0-nightly-20250218-cda2d11c1)
+  - React-RCTAnimation (0.79.0-nightly-20250218-cda2d11c1):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTAnimationHeaders
@@ -1277,7 +1217,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTAppDelegate (0.79.0-nightly-20250213-9a401c810):
+  - React-RCTAppDelegate (0.79.0-nightly-20250218-cda2d11c1):
     - RCT-Folly (= 2024.11.18.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1288,7 +1228,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
-    - React-jsc
+    - React-jsitooling
     - React-NativeModulesApple
     - React-RCTFabric
     - React-RCTFBReactNativeSpec
@@ -1300,7 +1240,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon
-  - React-RCTBlob (0.79.0-nightly-20250213-9a401c810):
+  - React-RCTBlob (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1313,7 +1253,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.79.0-nightly-20250213-9a401c810):
+  - React-RCTFabric (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly/Fabric (= 2024.11.18.00)
     - React-Core
@@ -1324,7 +1264,6 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - React-jsc
     - React-jsi
     - React-jsinspector
     - React-jsinspectortracing
@@ -1337,17 +1276,16 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTFBReactNativeSpec (0.79.0-nightly-20250213-9a401c810):
+  - React-RCTFBReactNativeSpec (0.79.0-nightly-20250218-cda2d11c1):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React-Core
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTImage (0.79.0-nightly-20250213-9a401c810):
+  - React-RCTImage (0.79.0-nightly-20250218-cda2d11c1):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTImageHeaders
@@ -1356,14 +1294,14 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.79.0-nightly-20250213-9a401c810):
-    - React-Core/RCTLinkingHeaders (= 0.79.0-nightly-20250213-9a401c810)
-    - React-jsi (= 0.79.0-nightly-20250213-9a401c810)
+  - React-RCTLinking (0.79.0-nightly-20250218-cda2d11c1):
+    - React-Core/RCTLinkingHeaders (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-jsi (= 0.79.0-nightly-20250218-cda2d11c1)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.79.0-nightly-20250213-9a401c810)
-  - React-RCTNetwork (0.79.0-nightly-20250213-9a401c810):
+    - ReactCommon/turbomodule/core (= 0.79.0-nightly-20250218-cda2d11c1)
+  - React-RCTNetwork (0.79.0-nightly-20250218-cda2d11c1):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTNetworkHeaders
@@ -1371,7 +1309,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTSettings (0.79.0-nightly-20250213-9a401c810):
+  - React-RCTSettings (0.79.0-nightly-20250218-cda2d11c1):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTSettingsHeaders
@@ -1379,39 +1317,39 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTText (0.79.0-nightly-20250213-9a401c810):
-    - React-Core/RCTTextHeaders (= 0.79.0-nightly-20250213-9a401c810)
+  - React-RCTText (0.79.0-nightly-20250218-cda2d11c1):
+    - React-Core/RCTTextHeaders (= 0.79.0-nightly-20250218-cda2d11c1)
     - Yoga
-  - React-RCTVibration (0.79.0-nightly-20250213-9a401c810):
+  - React-RCTVibration (0.79.0-nightly-20250218-cda2d11c1):
     - RCT-Folly (= 2024.11.18.00)
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-rendererconsistency (0.79.0-nightly-20250213-9a401c810)
-  - React-renderercss (0.79.0-nightly-20250213-9a401c810):
+  - React-rendererconsistency (0.79.0-nightly-20250218-cda2d11c1)
+  - React-renderercss (0.79.0-nightly-20250218-cda2d11c1):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.79.0-nightly-20250213-9a401c810):
+  - React-rendererdebug (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - RCT-Folly (= 2024.11.18.00)
     - React-debug
-  - React-rncore (0.79.0-nightly-20250213-9a401c810)
-  - React-RuntimeApple (0.79.0-nightly-20250213-9a401c810):
+  - React-rncore (0.79.0-nightly-20250218-cda2d11c1)
+  - React-RuntimeApple (0.79.0-nightly-20250218-cda2d11c1):
     - RCT-Folly/Fabric (= 2024.11.18.00)
     - React-callinvoker
     - React-Core/Default
     - React-CoreModules
     - React-cxxreact
     - React-featureflags
-    - React-jsc
     - React-jserrorhandler
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-Mapbuffer
     - React-NativeModulesApple
     - React-RCTFabric
@@ -1420,31 +1358,30 @@ PODS:
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-RuntimeCore (0.79.0-nightly-20250213-9a401c810):
+  - React-RuntimeCore (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly/Fabric (= 2024.11.18.00)
     - React-cxxreact
     - React-Fabric
     - React-featureflags
-    - React-jsc
     - React-jserrorhandler
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-performancetimeline
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-runtimeexecutor (0.79.0-nightly-20250213-9a401c810):
-    - React-jsi (= 0.79.0-nightly-20250213-9a401c810)
-  - React-runtimescheduler (0.79.0-nightly-20250213-9a401c810):
+  - React-runtimeexecutor (0.79.0-nightly-20250218-cda2d11c1):
+    - React-jsi (= 0.79.0-nightly-20250218-cda2d11c1)
+  - React-runtimescheduler (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly (= 2024.11.18.00)
     - React-callinvoker
     - React-cxxreact
     - React-debug
     - React-featureflags
-    - React-jsc
     - React-jsi
     - React-performancetimeline
     - React-rendererconsistency
@@ -1452,16 +1389,15 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - React-utils
-  - React-timing (0.79.0-nightly-20250213-9a401c810)
-  - React-utils (0.79.0-nightly-20250213-9a401c810):
+  - React-timing (0.79.0-nightly-20250218-cda2d11c1)
+  - React-utils (0.79.0-nightly-20250218-cda2d11c1):
     - glog
     - RCT-Folly (= 2024.11.18.00)
     - React-debug
-    - React-jsc
-    - React-jsi (= 0.79.0-nightly-20250213-9a401c810)
-  - ReactAppDependencyProvider (0.79.0-nightly-20250213-9a401c810):
+    - React-jsi (= 0.79.0-nightly-20250218-cda2d11c1)
+  - ReactAppDependencyProvider (0.79.0-nightly-20250218-cda2d11c1):
     - ReactCodegen
-  - ReactCodegen (0.79.0-nightly-20250213-9a401c810):
+  - ReactCodegen (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - glog
     - RCT-Folly
@@ -1473,7 +1409,6 @@ PODS:
     - React-FabricImage
     - React-featureflags
     - React-graphics
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-NativeModulesApple
@@ -1482,46 +1417,46 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - ReactCommon (0.79.0-nightly-20250213-9a401c810):
-    - ReactCommon/turbomodule (= 0.79.0-nightly-20250213-9a401c810)
-  - ReactCommon/turbomodule (0.79.0-nightly-20250213-9a401c810):
+  - ReactCommon (0.79.0-nightly-20250218-cda2d11c1):
+    - ReactCommon/turbomodule (= 0.79.0-nightly-20250218-cda2d11c1)
+  - ReactCommon/turbomodule (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-nightly-20250213-9a401c810)
-    - React-cxxreact (= 0.79.0-nightly-20250213-9a401c810)
-    - React-jsi (= 0.79.0-nightly-20250213-9a401c810)
-    - React-logger (= 0.79.0-nightly-20250213-9a401c810)
-    - React-perflogger (= 0.79.0-nightly-20250213-9a401c810)
-    - ReactCommon/turbomodule/bridging (= 0.79.0-nightly-20250213-9a401c810)
-    - ReactCommon/turbomodule/core (= 0.79.0-nightly-20250213-9a401c810)
-  - ReactCommon/turbomodule/bridging (0.79.0-nightly-20250213-9a401c810):
+    - React-callinvoker (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-cxxreact (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-jsi (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-logger (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-perflogger (= 0.79.0-nightly-20250218-cda2d11c1)
+    - ReactCommon/turbomodule/bridging (= 0.79.0-nightly-20250218-cda2d11c1)
+    - ReactCommon/turbomodule/core (= 0.79.0-nightly-20250218-cda2d11c1)
+  - ReactCommon/turbomodule/bridging (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-nightly-20250213-9a401c810)
-    - React-cxxreact (= 0.79.0-nightly-20250213-9a401c810)
-    - React-jsi (= 0.79.0-nightly-20250213-9a401c810)
-    - React-logger (= 0.79.0-nightly-20250213-9a401c810)
-    - React-perflogger (= 0.79.0-nightly-20250213-9a401c810)
-  - ReactCommon/turbomodule/core (0.79.0-nightly-20250213-9a401c810):
+    - React-callinvoker (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-cxxreact (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-jsi (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-logger (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-perflogger (= 0.79.0-nightly-20250218-cda2d11c1)
+  - ReactCommon/turbomodule/core (0.79.0-nightly-20250218-cda2d11c1):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-nightly-20250213-9a401c810)
-    - React-cxxreact (= 0.79.0-nightly-20250213-9a401c810)
-    - React-debug (= 0.79.0-nightly-20250213-9a401c810)
-    - React-featureflags (= 0.79.0-nightly-20250213-9a401c810)
-    - React-jsi (= 0.79.0-nightly-20250213-9a401c810)
-    - React-logger (= 0.79.0-nightly-20250213-9a401c810)
-    - React-perflogger (= 0.79.0-nightly-20250213-9a401c810)
-    - React-utils (= 0.79.0-nightly-20250213-9a401c810)
+    - React-callinvoker (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-cxxreact (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-debug (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-featureflags (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-jsi (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-logger (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-perflogger (= 0.79.0-nightly-20250218-cda2d11c1)
+    - React-utils (= 0.79.0-nightly-20250218-cda2d11c1)
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
 
@@ -1560,11 +1495,13 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector-modern`)
   - React-jsinspectortracing (from `../node_modules/react-native/ReactCommon/jsinspector-modern/tracing`)
+  - React-jsitooling (from `../node_modules/react-native/ReactCommon/jsitooling`)
   - React-jsitracing (from `../node_modules/react-native/ReactCommon/hermes/executor/`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
+  - React-oscompat (from `../node_modules/react-native/ReactCommon/oscompat`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-performancetimeline (from `../node_modules/react-native/ReactCommon/react/performance/timeline`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
@@ -1663,6 +1600,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector-modern"
   React-jsinspectortracing:
     :path: "../node_modules/react-native/ReactCommon/jsinspector-modern/tracing"
+  React-jsitooling:
+    :path: "../node_modules/react-native/ReactCommon/jsitooling"
   React-jsitracing:
     :path: "../node_modules/react-native/ReactCommon/hermes/executor/"
   React-logger:
@@ -1673,6 +1612,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
   React-NativeModulesApple:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios"
+  React-oscompat:
+    :path: "../node_modules/react-native/ReactCommon/oscompat"
   React-perflogger:
     :path: "../node_modules/react-native/ReactCommon/reactperflogger"
   React-performancetimeline:
@@ -1734,70 +1675,72 @@ SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
-  FBLazyVector: 1a622d338806866cda0ef0622d0cd4ca9cda11a3
+  FBLazyVector: b6275bea4954e7fe6c1173ba8f7c96ef9bfeec8f
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
-  RCTDeprecation: 33b6ee3a38dfca459f5d72ef71a1a88b4599cd49
-  RCTRequired: 76b8607018ad8d1ac68cbd8e2dac887214d4b161
-  RCTTypeSafety: 4e6de0c8fba7b69b787b6d6d222c3df3e9500c08
-  React: 350034271d4060118467428a0457574c1e06fc4d
-  React-callinvoker: 6dfcc0e089334e848523b2c26ea88335ea507f17
-  React-Core: be70e35198205c0b4551cc03a4f21c74042369d4
-  React-CoreModules: d27965d08298f22d282c66bfdadbfc3ade2b6605
-  React-cxxreact: c8f946977a1c7890be7a1633c9e0af579ac6c3fe
-  React-debug: 00f55ef88e72e517b9ac3c99887bc72cfbcbfeaf
-  React-defaultsnativemodule: 4c0fc66d5b202a217985c93487bd6581c726f1f0
-  React-domnativemodule: 7f8404464c53a8b4dfe5f754029e47b90a36ba9f
-  React-Fabric: 90340693bd9a795eafd7a987691e9b8cfc1fd56c
-  React-FabricComponents: 26a3da150a2e11c4ab1c51dfa1715d5da12550d6
-  React-FabricImage: d7e765daa675eec98e64e5dbc9dc70918c32e788
-  React-featureflags: 350cacccf30d111b3cc70d9c128eabf20fead7ac
-  React-featureflagsnativemodule: 5642ce196d457ce2600e9c12aa88adee9b6ca10b
-  React-graphics: d607957b4698a74cd7855ae36cb0af5e200c9b61
-  React-idlecallbacksnativemodule: 76200e41cff8d3105586681e5351d88e7bc733ee
-  React-ImageManager: 4035ff63a19d94228124c797a506772188c93cea
-  React-jsc: 693933c09217dbfd9296402cbd92481b4b2f0488
-  React-jserrorhandler: e1b8f41d99f02b395379d99f8f4518855085503a
-  React-jsi: 3224e840fae61351ab2a2e0afde29f8097f2a24b
-  React-jsiexecutor: 886abddbe6178487f58389715e27dd40ff537bf4
-  React-jsinspector: 47d795a0afd18568a583161177f07a4884b7e244
-  React-jsinspectortracing: 388862861bb231d06aeab79ed344d3267ab4bab2
-  React-jsitracing: a03b7e875e1f981e04c4a23fb1e1dce9fa65ff80
-  React-logger: 0431ee35e39cf2147e7344f38b328f24e291ea0d
-  React-Mapbuffer: 1680c0740aa1a3ff743769ebe9d00a57bb9fe126
-  React-microtasksnativemodule: 61f1bb33cc9d66ff4d566ddb27c6db98cb8a7c0f
-  React-NativeModulesApple: e44b2ff1284f31e7322a027d39bbad95d3c19ddf
-  React-perflogger: fd994cb910faef5442ae16b2a07f85fed35d069e
-  React-performancetimeline: 3ffd99c4bf3bd2189b8a5d4a0d6a28a105c0481c
-  React-RCTActionSheet: 272ec9e91d1ed4931cb8aef0d3ed3795e2f0c4c9
-  React-RCTAnimation: 3b18f47b995ab525bb20a757bef379640a729439
-  React-RCTAppDelegate: c96249aa5d2f678e0a0530a8014cba08d8ddc4ca
-  React-RCTBlob: 00f080ff9a1957fbb65b1167ed9143c942147530
-  React-RCTFabric: b25a1c3622e269dbc5aed50f7202c1e0d7dbf98b
-  React-RCTFBReactNativeSpec: 1b68ec77e6772742815949e4e26133b94e9ece5c
-  React-RCTImage: dc9f08ad3e42de993328afec50da2b57d56702a1
-  React-RCTLinking: 90e79b75e1e0bc06ff3e30cee731fa7f6a5394c6
-  React-RCTNetwork: 07beef438f70511c5fe767b34edd1dd199732c03
-  React-RCTSettings: 6a323ee163d29f2531ffb1136b506430ae267a63
-  React-RCTText: 36b7da62fb8a59b212b59bb5f7afaf4faccca100
-  React-RCTVibration: 6d9e272975089d2fdf1b7d7aeff89effd8598419
-  React-rendererconsistency: 4da81fa34ad8efd63d67e58b7551235f1edab66c
-  React-renderercss: ac51b40fc6ea4c4451493fabd50abef5ff4790c7
-  React-rendererdebug: a624613ed29a0fd5cdb1a328661125385410683b
-  React-rncore: 8be676648a97ba9107b5b9d499ced4fff18e6959
-  React-RuntimeApple: 9d0c37b44f76469d2fadae6a26b30c1d11b47f2c
-  React-RuntimeCore: 5fd32c54156ad916c97be2e850ae1da25ad956a4
-  React-runtimeexecutor: a47a1f9d652d4c4c59b8735d5f76cc43a011bf76
-  React-runtimescheduler: 31a25985ddf399d3963e0121a2a5ff2e1c003aa3
-  React-timing: 8d512ce9afe8ac2dc93add1e73a2a7f50e0a31f9
-  React-utils: 094dced4e3170d1303b949f1764bccef18f4e7f0
-  ReactAppDependencyProvider: 4ba86feb310b3b2482afb1a3455c07cad980f437
-  ReactCodegen: a764d796f4adf4656dee1077213f52b3fb190ea7
-  ReactCommon: 91081f5aae0d526caf0e50ecae94e2c98ffec48c
+  RCTDeprecation: 5ac2ed490468a85291684cec88401ae9ce88e030
+  RCTRequired: f70d99017e6077878afecde4aa5e7de90a6a56f8
+  RCTTypeSafety: d15db5bfbf5e7968af8414e1209686cac8e15c39
+  React: adcedd94e5a272f972999bdd78b78cd66aad86f1
+  React-callinvoker: 621db21c586c98ce4b667c39b34f07c4f5918957
+  React-Core: 15291c2263a325da81276e2838b172ce0966ce63
+  React-CoreModules: 31954136ba2e5d17a57066d35a2becd3b1e16bbc
+  React-cxxreact: 23bdd8459d56b38f5dff72128a39108d49bae522
+  React-debug: c0e04b090ccf1a01bc854da41bc519d048e1db53
+  React-defaultsnativemodule: 94303c9c6a5fe432700bfa121ba9d0003d89b987
+  React-domnativemodule: 7fd3d5174334901c844ff97c6614cd394f057498
+  React-Fabric: 2faf73e7bde436953d107e2a90cb39225453395b
+  React-FabricComponents: 4731c723798e29c4a7fde7a0180df2dbcababa96
+  React-FabricImage: e9a22bb5d29b28fe6f58a21307928cc291c7f222
+  React-featureflags: aaf9a11fe65b464bb1f79484bead711165688cc3
+  React-featureflagsnativemodule: 66522572c43480cd22e146b395a55d9f03352dbf
+  React-graphics: 9d9145d78d5bba6217ce8b419df7dac678ff742c
+  React-idlecallbacksnativemodule: 98b3c2bc74bba1f50b004b1609b59444f94e7e09
+  React-ImageManager: 18f21543a95b75c904995dcef0f6c6a6eb608342
+  React-jsc: 56d4e28446f52a29b3a9aac9663ab51927927221
+  React-jserrorhandler: ad33ae5032f6ea9fada6b78040d5356b1b771f26
+  React-jsi: 7dec699dbe03bb5a70c75808ece049afd5a0dfc5
+  React-jsiexecutor: 7a7ca4f124daf6e2686b4cb97b434f632e36dcfa
+  React-jsinspector: 1d0f2ed6177c88d17839b7db521508dc0d00144a
+  React-jsinspectortracing: 4c627f20be00d4695cf2ec2d771c3bc86f8c61b3
+  React-jsitooling: c9f894bc315348606b47e00aec7348780996673a
+  React-jsitracing: da9dcaca094226b3a39a2c9b12b3764190e581fb
+  React-logger: 5a1b8ffeccc1dedb3a59e0ba4156830632222945
+  React-Mapbuffer: 266c4d4204bdba4f6f4e8f134c3dd90ca1e877cd
+  React-microtasksnativemodule: 459b7cbebb0d77d3908a01938abbf7ea87bc3cc6
+  React-NativeModulesApple: 414f784b35e505dc7ca98564f3ecaacb25378cd1
+  React-oscompat: 89ec75f2c9deabd078cfa79e2f84c65cfb771faf
+  React-perflogger: 88bc252476797f828b6fecf04e89f905014914a1
+  React-performancetimeline: fea977f7004a3b96673f7def290ebd174b6e71c2
+  React-RCTActionSheet: e8eaade91cfa889519c8041258d7a50832eeed09
+  React-RCTAnimation: 683931bf343522e6a067cd6b2dcc7a3b229d9b5e
+  React-RCTAppDelegate: 4ef61a9c92987c2c92bf3daf3b115762f4892e6e
+  React-RCTBlob: 46ecca2a7f47410607ab446e2335a2bee7852875
+  React-RCTFabric: 4839aca95297c5ffdc55b9094f322bb71fcd3aae
+  React-RCTFBReactNativeSpec: 528c3c73bee8925c6c735f5ec272022cac3c7c73
+  React-RCTImage: 10b44d81490fd1dd15c30c92a4767040d42e7699
+  React-RCTLinking: 380d01a145622dbe1f94e78f57cf4b3a1904c2f1
+  React-RCTNetwork: f140dc70b9fc2936f703bdf1d34bd69684049c54
+  React-RCTSettings: c0eab24466a63f5cbc4412bb1e1c51d8151616a3
+  React-RCTText: 9ed61f034fcf27b5aba250d1e0add5cbada3975a
+  React-RCTVibration: 5f667fc94547009b4ae1f8c153a2d9c9d6ce87a8
+  React-rendererconsistency: 4403e687ff2a5f40f5c1bbbcd5df7cc342c0338f
+  React-renderercss: 6af18d12904945d34fa0238de1332a076b513625
+  React-rendererdebug: e92b0eff88c652b94008356962abb7d800df93a9
+  React-rncore: 6649600457e5d56aa3678c30436002db8eb73752
+  React-RuntimeApple: 52a353d983ea9974d47c71c3e136f0649ab8b018
+  React-RuntimeCore: 8b292fd4fa40a20c8c3a64e53d1fbcc61921c1ae
+  React-runtimeexecutor: 343304ca59d6fd7a57a92c77227fcc3f3296e410
+  React-runtimescheduler: 479e21105cf3e6e34767184ab1ed53d1b869a6d0
+  React-timing: 05925220f62b53ef5472bf830c930a22dfefab7f
+  React-utils: 3ddbc31f99dbdc0a61d8047ddcee447ae29e41ed
+  ReactAppDependencyProvider: f7b14564935beeaf6b2c76dd96045095f1e52d2b
+  ReactCodegen: d8a868133920280969cffa52322a800a3991d681
+  ReactCommon: 195c404e60b906f1effec7933741172c54889525
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 482a4ab00f9e5257dded8263d2985bdf085bc920
+  Yoga: f90f4e1485051b28e754b067ef45b48b34a5fb75
 
-PODFILE CHECKSUM: bf5ad86864737b4a9d39c7d7ce9b3d2f434a6c2b
+PODFILE CHECKSUM: 5679d046b9b3e62f39bb78691ffa133428cea30d
 
 COCOAPODS: 1.15.2

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -61,28 +61,28 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
-      "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
+      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.7.tgz",
-      "integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
+      "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.5",
+        "@babel/generator": "^7.26.9",
         "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.7",
-        "@babel/parser": "^7.26.7",
-        "@babel/template": "^7.25.9",
-        "@babel/traverse": "^7.26.7",
-        "@babel/types": "^7.26.7",
+        "@babel/helpers": "^7.26.9",
+        "@babel/parser": "^7.26.9",
+        "@babel/template": "^7.26.9",
+        "@babel/traverse": "^7.26.9",
+        "@babel/types": "^7.26.9",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.26.5.tgz",
-      "integrity": "sha512-Kkm8C8uxI842AwQADxl0GbcG1rupELYLShazYEZO/2DYjhyWXJIOUVOE3tBYm6JXzUCNJOZEzqc4rCW/jsEQYQ==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.26.8.tgz",
+      "integrity": "sha512-3tBctaHRW6xSub26z7n8uyOTwwUsCdvIug/oxBH9n6yCO5hMj2vwDJAo7RbBMKrM7P+W2j61zLKviJQFGOYKMg==",
       "dev": true,
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
@@ -116,12 +116,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
-      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.9.tgz",
+      "integrity": "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==",
       "dependencies": {
-        "@babel/parser": "^7.26.5",
-        "@babel/types": "^7.26.5",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -157,16 +157,16 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
-      "integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.26.9.tgz",
+      "integrity": "sha512-ubbUqCofvxPRurw5L8WTsCLSkQiVpov4Qx0WMA+jUN+nXBK8ADPlJO1grkFw5CWKC5+sZSOfuGMdX1aI1iT9Sg==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-member-expression-to-functions": "^7.25.9",
         "@babel/helper-optimise-call-expression": "^7.25.9",
-        "@babel/helper-replace-supers": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.26.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
-        "@babel/traverse": "^7.25.9",
+        "@babel/traverse": "^7.26.9",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -348,23 +348,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
-      "integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
+      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.7"
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
-      "integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
+      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
       "dependencies": {
-        "@babel/types": "^7.26.7"
+        "@babel/types": "^7.26.9"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -760,13 +760,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.9.tgz",
-      "integrity": "sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.26.8.tgz",
+      "integrity": "sha512-He9Ej2X7tNf2zdKMAGOsmg2MrFc+hfoAhd3po4cWfo/NWjzEAKa0oQruj1ROVUdl0e6fb6/kE/G3SSxE0lRJOg==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-remap-async-to-generator": "^7.25.9",
-        "@babel/traverse": "^7.25.9"
+        "@babel/traverse": "^7.26.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -999,11 +999,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.9.tgz",
-      "integrity": "sha512-LqHxduHoaGELJl2uhImHwRQudhCM50pT46rIBNvtT/Oql3nqiS3wOwP+5ten7NpYSXrrVLgtZU3DZmPtWZo16A==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.26.9.tgz",
+      "integrity": "sha512-Hry8AusVm8LW5BVFgiyUReuoGzPUpdHQQqJY5bZnbbf+ngOHWuCuYFKw/BqaaWlvEUrF91HMhDtEaI1hZzNbLg==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
       },
       "engines": {
@@ -1428,12 +1428,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.9.tgz",
-      "integrity": "sha512-nZp7GlEl+yULJrClz0SwHPqir3lc0zsPrDHQUcxGspSL7AKrexNSEfTbfqnDNJUO13bgKyfuOLMF8Xqtu8j3YQ==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.26.9.tgz",
+      "integrity": "sha512-Jf+8y9wXQbbxvVYTM8gO5oEF2POdNji0NMltEkG7FtmzD9PVz7/lxpqSdTvwsjTMU5HIHuDVNf2SOxLkWi+wPQ==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.26.5",
         "babel-plugin-polyfill-corejs2": "^0.4.10",
         "babel-plugin-polyfill-corejs3": "^0.10.6",
         "babel-plugin-polyfill-regenerator": "^0.6.1",
@@ -1444,6 +1444,18 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
+      "integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.6.2",
+        "core-js-compat": "^3.38.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
@@ -1490,11 +1502,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.9.tgz",
-      "integrity": "sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.26.8.tgz",
+      "integrity": "sha512-OmGDL5/J0CJPJZTHZbi2XpO0tyT2Ia7fzpW5GURwdtp2X3fMmN8au/ej6peC/T33/+CRiIpA8Krse8hFGVmT5Q==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.26.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1518,9 +1530,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.7.tgz",
-      "integrity": "sha512-5cJurntg+AT+cgelGP9Bt788DKiAw9gIMSMU2NJrLAilnj0m8WZWUNZPSLOmadYsujHutpgElO+50foX+ib/Wg==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.8.tgz",
+      "integrity": "sha512-bME5J9AC8ChwA7aEPJ6zym3w7aObZULHhbNLU0bKUhKsAkylkzUdq+0kdymh9rzi8nlNFl2bmldFBCKNJBUpuw==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-create-class-features-plugin": "^7.25.9",
@@ -1595,11 +1607,11 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.7.tgz",
-      "integrity": "sha512-Ycg2tnXwixaXOVb29rana8HNPgLVBof8qqtNQ9LE22IoyZboQbGSxI6ZySMdW3K5nAe6gu35IaJefUJflhUFTQ==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.9.tgz",
+      "integrity": "sha512-vX3qPGE8sEKEAZCWk05k3cpTAE3/nOYca++JA+Rd0z2NCNzabmYvEiSShKzm10zdquOIAVXsy2Ei/DTW34KlKQ==",
       "dependencies": {
-        "@babel/compat-data": "^7.26.5",
+        "@babel/compat-data": "^7.26.8",
         "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-validator-option": "^7.25.9",
@@ -1613,7 +1625,7 @@
         "@babel/plugin-syntax-import-attributes": "^7.26.0",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.25.9",
-        "@babel/plugin-transform-async-generator-functions": "^7.25.9",
+        "@babel/plugin-transform-async-generator-functions": "^7.26.8",
         "@babel/plugin-transform-async-to-generator": "^7.25.9",
         "@babel/plugin-transform-block-scoped-functions": "^7.26.5",
         "@babel/plugin-transform-block-scoping": "^7.25.9",
@@ -1628,7 +1640,7 @@
         "@babel/plugin-transform-dynamic-import": "^7.25.9",
         "@babel/plugin-transform-exponentiation-operator": "^7.26.3",
         "@babel/plugin-transform-export-namespace-from": "^7.25.9",
-        "@babel/plugin-transform-for-of": "^7.25.9",
+        "@babel/plugin-transform-for-of": "^7.26.9",
         "@babel/plugin-transform-function-name": "^7.25.9",
         "@babel/plugin-transform-json-strings": "^7.25.9",
         "@babel/plugin-transform-literals": "^7.25.9",
@@ -1656,7 +1668,7 @@
         "@babel/plugin-transform-shorthand-properties": "^7.25.9",
         "@babel/plugin-transform-spread": "^7.25.9",
         "@babel/plugin-transform-sticky-regex": "^7.25.9",
-        "@babel/plugin-transform-template-literals": "^7.25.9",
+        "@babel/plugin-transform-template-literals": "^7.26.8",
         "@babel/plugin-transform-typeof-symbol": "^7.26.7",
         "@babel/plugin-transform-unicode-escapes": "^7.25.9",
         "@babel/plugin-transform-unicode-property-regex": "^7.25.9",
@@ -1664,9 +1676,9 @@
         "@babel/plugin-transform-unicode-sets-regex": "^7.25.9",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
         "babel-plugin-polyfill-corejs2": "^0.4.10",
-        "babel-plugin-polyfill-corejs3": "^0.10.6",
+        "babel-plugin-polyfill-corejs3": "^0.11.0",
         "babel-plugin-polyfill-regenerator": "^0.6.1",
-        "core-js-compat": "^3.38.1",
+        "core-js-compat": "^3.40.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -1771,9 +1783,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
-      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
+      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1782,28 +1794,28 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.7.tgz",
-      "integrity": "sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.9.tgz",
+      "integrity": "sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.5",
-        "@babel/parser": "^7.26.7",
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.7",
+        "@babel/generator": "^7.26.9",
+        "@babel/parser": "^7.26.9",
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.9",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1813,15 +1825,15 @@
     },
     "node_modules/@babel/traverse--for-generate-function-map": {
       "name": "@babel/traverse",
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.7.tgz",
-      "integrity": "sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.9.tgz",
+      "integrity": "sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.5",
-        "@babel/parser": "^7.26.7",
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.7",
+        "@babel/generator": "^7.26.9",
+        "@babel/parser": "^7.26.9",
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.9",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1830,9 +1842,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
-      "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
+      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -2624,37 +2636,6 @@
         "fast-glob": "^3.3.2"
       }
     },
-    "node_modules/@react-native-community/cli-clean/node_modules/@react-native-community/cli-tools": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-15.0.1.tgz",
-      "integrity": "sha512-N79A+u/94roanfmNohVcNGu6Xg+0idh63JHZFLC9OJJuZwTifGMLDfSTHZATpR1J7rebozQ5ClcSUePavErnSg==",
-      "dev": true,
-      "dependencies": {
-        "appdirsjs": "^1.2.4",
-        "chalk": "^4.1.2",
-        "execa": "^5.0.0",
-        "find-up": "^5.0.0",
-        "mime": "^2.4.1",
-        "open": "^6.2.0",
-        "ora": "^5.4.1",
-        "prompts": "^2.4.2",
-        "semver": "^7.5.2",
-        "shell-quote": "^1.7.3",
-        "sudo-prompt": "^9.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-clean/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@react-native-community/cli-config": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-15.0.1.tgz",
@@ -2681,74 +2662,11 @@
         "fast-glob": "^3.3.2"
       }
     },
-    "node_modules/@react-native-community/cli-config-apple/node_modules/@react-native-community/cli-tools": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-15.0.1.tgz",
-      "integrity": "sha512-N79A+u/94roanfmNohVcNGu6Xg+0idh63JHZFLC9OJJuZwTifGMLDfSTHZATpR1J7rebozQ5ClcSUePavErnSg==",
-      "dev": true,
-      "dependencies": {
-        "appdirsjs": "^1.2.4",
-        "chalk": "^4.1.2",
-        "execa": "^5.0.0",
-        "find-up": "^5.0.0",
-        "mime": "^2.4.1",
-        "open": "^6.2.0",
-        "ora": "^5.4.1",
-        "prompts": "^2.4.2",
-        "semver": "^7.5.2",
-        "shell-quote": "^1.7.3",
-        "sudo-prompt": "^9.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-config-apple/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/@react-native-community/cli-tools": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-15.0.1.tgz",
-      "integrity": "sha512-N79A+u/94roanfmNohVcNGu6Xg+0idh63JHZFLC9OJJuZwTifGMLDfSTHZATpR1J7rebozQ5ClcSUePavErnSg==",
-      "dev": true,
-      "dependencies": {
-        "appdirsjs": "^1.2.4",
-        "chalk": "^4.1.2",
-        "execa": "^5.0.0",
-        "find-up": "^5.0.0",
-        "mime": "^2.4.1",
-        "open": "^6.2.0",
-        "ora": "^5.4.1",
-        "prompts": "^2.4.2",
-        "semver": "^7.5.2",
-        "shell-quote": "^1.7.3",
-        "sudo-prompt": "^9.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@react-native-community/cli-debugger-ui": {
-      "version": "15.1.3",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-15.1.3.tgz",
-      "integrity": "sha512-m+fb9iAUNb9WiDdokCBLh0InJvollcgAM3gLjCT8DGTP6bH/jxtZ3DszzyIRqN9cMamItVrvDM0vkIg48xK7rQ==",
-      "optional": true,
-      "peer": true,
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-15.0.1.tgz",
+      "integrity": "sha512-xkT2TLS8zg5r7Vl9l/2f7JVUoFECnVBS+B5ivrSu2PNZhKkr9lRmJFxC9aVLFb5lIxQQKNDvEyiIDNfP7wjJiA==",
+      "devOptional": true,
       "dependencies": {
         "serve-static": "^1.13.1"
       }
@@ -2777,25 +2695,6 @@
         "yaml": "^2.2.1"
       }
     },
-    "node_modules/@react-native-community/cli-doctor/node_modules/@react-native-community/cli-tools": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-15.0.1.tgz",
-      "integrity": "sha512-N79A+u/94roanfmNohVcNGu6Xg+0idh63JHZFLC9OJJuZwTifGMLDfSTHZATpR1J7rebozQ5ClcSUePavErnSg==",
-      "dev": true,
-      "dependencies": {
-        "appdirsjs": "^1.2.4",
-        "chalk": "^4.1.2",
-        "execa": "^5.0.0",
-        "find-up": "^5.0.0",
-        "mime": "^2.4.1",
-        "open": "^6.2.0",
-        "ora": "^5.4.1",
-        "prompts": "^2.4.2",
-        "semver": "^7.5.2",
-        "shell-quote": "^1.7.3",
-        "sudo-prompt": "^9.0.0"
-      }
-    },
     "node_modules/@react-native-community/cli-doctor/node_modules/semver": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
@@ -2822,37 +2721,6 @@
         "logkitty": "^0.7.1"
       }
     },
-    "node_modules/@react-native-community/cli-platform-android/node_modules/@react-native-community/cli-tools": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-15.0.1.tgz",
-      "integrity": "sha512-N79A+u/94roanfmNohVcNGu6Xg+0idh63JHZFLC9OJJuZwTifGMLDfSTHZATpR1J7rebozQ5ClcSUePavErnSg==",
-      "dev": true,
-      "dependencies": {
-        "appdirsjs": "^1.2.4",
-        "chalk": "^4.1.2",
-        "execa": "^5.0.0",
-        "find-up": "^5.0.0",
-        "mime": "^2.4.1",
-        "open": "^6.2.0",
-        "ora": "^5.4.1",
-        "prompts": "^2.4.2",
-        "semver": "^7.5.2",
-        "shell-quote": "^1.7.3",
-        "sudo-prompt": "^9.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-android/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@react-native-community/cli-platform-apple": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-apple/-/cli-platform-apple-15.0.1.tgz",
@@ -2866,37 +2734,6 @@
         "fast-xml-parser": "^4.4.1"
       }
     },
-    "node_modules/@react-native-community/cli-platform-apple/node_modules/@react-native-community/cli-tools": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-15.0.1.tgz",
-      "integrity": "sha512-N79A+u/94roanfmNohVcNGu6Xg+0idh63JHZFLC9OJJuZwTifGMLDfSTHZATpR1J7rebozQ5ClcSUePavErnSg==",
-      "dev": true,
-      "dependencies": {
-        "appdirsjs": "^1.2.4",
-        "chalk": "^4.1.2",
-        "execa": "^5.0.0",
-        "find-up": "^5.0.0",
-        "mime": "^2.4.1",
-        "open": "^6.2.0",
-        "ora": "^5.4.1",
-        "prompts": "^2.4.2",
-        "semver": "^7.5.2",
-        "shell-quote": "^1.7.3",
-        "sudo-prompt": "^9.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-apple/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@react-native-community/cli-platform-ios": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-15.0.1.tgz",
@@ -2907,14 +2744,13 @@
       }
     },
     "node_modules/@react-native-community/cli-server-api": {
-      "version": "15.1.3",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-15.1.3.tgz",
-      "integrity": "sha512-kXZ0evedluLt6flWQiI3JqwnW8rSBspOoQ7JVTQYiG5lDHAeL3Om9PjAyiQBg1EZRMjiWZDV7nDxhR+m+6NX5Q==",
-      "optional": true,
-      "peer": true,
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-15.0.1.tgz",
+      "integrity": "sha512-f3rb3t1ELLaMSX5/LWO/IykglBIgiP3+pPnyl8GphHnBpf3bdIcp7fHlHLemvHE06YxT2nANRxRPjy1gNskenA==",
+      "devOptional": true,
       "dependencies": {
-        "@react-native-community/cli-debugger-ui": "15.1.3",
-        "@react-native-community/cli-tools": "15.1.3",
+        "@react-native-community/cli-debugger-ui": "15.0.1",
+        "@react-native-community/cli-tools": "15.0.1",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.1",
@@ -2925,11 +2761,10 @@
       }
     },
     "node_modules/@react-native-community/cli-tools": {
-      "version": "15.1.3",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-15.1.3.tgz",
-      "integrity": "sha512-2RzoUKR+Y03ijBeeSoCSQihyN6dxy3fbHjraO4MheZZUzt/Yd1VMEDd0R5aa6rtiRDoknbHt45RL2GMa8MSaEA==",
-      "optional": true,
-      "peer": true,
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-15.0.1.tgz",
+      "integrity": "sha512-N79A+u/94roanfmNohVcNGu6Xg+0idh63JHZFLC9OJJuZwTifGMLDfSTHZATpR1J7rebozQ5ClcSUePavErnSg==",
+      "devOptional": true,
       "dependencies": {
         "appdirsjs": "^1.2.4",
         "chalk": "^4.1.2",
@@ -2948,8 +2783,7 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "optional": true,
-      "peer": true,
+      "devOptional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2966,51 +2800,6 @@
         "joi": "^17.2.1"
       }
     },
-    "node_modules/@react-native-community/cli/node_modules/@react-native-community/cli-debugger-ui": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-15.0.1.tgz",
-      "integrity": "sha512-xkT2TLS8zg5r7Vl9l/2f7JVUoFECnVBS+B5ivrSu2PNZhKkr9lRmJFxC9aVLFb5lIxQQKNDvEyiIDNfP7wjJiA==",
-      "dev": true,
-      "dependencies": {
-        "serve-static": "^1.13.1"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/@react-native-community/cli-server-api": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-15.0.1.tgz",
-      "integrity": "sha512-f3rb3t1ELLaMSX5/LWO/IykglBIgiP3+pPnyl8GphHnBpf3bdIcp7fHlHLemvHE06YxT2nANRxRPjy1gNskenA==",
-      "dev": true,
-      "dependencies": {
-        "@react-native-community/cli-debugger-ui": "15.0.1",
-        "@react-native-community/cli-tools": "15.0.1",
-        "compression": "^1.7.1",
-        "connect": "^3.6.5",
-        "errorhandler": "^1.5.1",
-        "nocache": "^3.0.1",
-        "pretty-format": "^26.6.2",
-        "serve-static": "^1.13.1",
-        "ws": "^6.2.3"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/@react-native-community/cli-tools": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-15.0.1.tgz",
-      "integrity": "sha512-N79A+u/94roanfmNohVcNGu6Xg+0idh63JHZFLC9OJJuZwTifGMLDfSTHZATpR1J7rebozQ5ClcSUePavErnSg==",
-      "dev": true,
-      "dependencies": {
-        "appdirsjs": "^1.2.4",
-        "chalk": "^4.1.2",
-        "execa": "^5.0.0",
-        "find-up": "^5.0.0",
-        "mime": "^2.4.1",
-        "open": "^6.2.0",
-        "ora": "^5.4.1",
-        "prompts": "^2.4.2",
-        "semver": "^7.5.2",
-        "shell-quote": "^1.7.3",
-        "sudo-prompt": "^9.0.0"
-      }
-    },
     "node_modules/@react-native-community/cli/node_modules/semver": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
@@ -3024,29 +2813,29 @@
       }
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-YbpvfiL2yAQBJOsonxdWjYhi4IIMMJfWIVVUti3yjJdzEkym/TkSpD0JgkGEJ+jF55hTmH4C/aJG1wpR62zApA==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-KHKgu/Gt2KNqLJ4fII5L67cmo5s5boXkwpB6nVVQtnmhwd4qTZNKCUC2QDK3zwqaBY/f4Ty/XdXAFTxymB3Kkg==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-HrroeMwd+t9rQPFO+hwVogxnGN7+E3k8zR+/Uy+3QfoIu7r3hVp09IQZAhw5FSOHXH5P3K2jKkE2lZ4dWMrfyw==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-Ws20vOVgNRmb/Wm2TMZE5rilMcmBhZVszq3OL8lSwATfNDS3Qnn1PDXU17lEBtNvk8WYcmB9Lxs3mpdZkmuWfQ==",
       "dependencies": {
         "@babel/traverse": "^7.25.3",
-        "@react-native/codegen": "0.79.0-nightly-20250213-9a401c810"
+        "@react-native/codegen": "0.79.0-nightly-20250218-cda2d11c1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/babel-preset": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-BMW1SzdhwX3Y1EazKFTE0IaZ6kySq+YhKdl10D5jVeyO4KMbupcWbPEJ+1+q51mIBQsctcSEvOJrG0JzLKqEtw==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-i+tv5lDixKrdMGoPiaSaV4NoBUgqt/hMCHy2t8rkQyQ8ZwiP8CIBcRiTLNITtJbQoxRlqNXG0BMtem2LKvci5g==",
       "dependencies": {
         "@babel/core": "^7.25.2",
         "@babel/plugin-proposal-export-default-from": "^7.24.7",
@@ -3089,7 +2878,7 @@
         "@babel/plugin-transform-typescript": "^7.25.2",
         "@babel/plugin-transform-unicode-regex": "^7.24.7",
         "@babel/template": "^7.25.0",
-        "@react-native/babel-plugin-codegen": "0.79.0-nightly-20250213-9a401c810",
+        "@react-native/babel-plugin-codegen": "0.79.0-nightly-20250218-cda2d11c1",
         "babel-plugin-syntax-hermes-parser": "0.25.1",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
@@ -3102,9 +2891,9 @@
       }
     },
     "node_modules/@react-native/codegen": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-njrIpsZnO1Uw1rwNKyLyQN3DtbhneM054sF2fBVuLYPcEXWemdQls2pcX96SJ0MoScgf7niX30bkL4CQRZZYZQ==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-3wM8Hc9EnfUbzMPOiwJi4zmTppRXHeAPNc7IU+KGGmNcj7UKspE2kft3wHKxqMKytjUq7w8I3lkC3FArJLRygg==",
       "dependencies": {
         "@babel/parser": "^7.25.3",
         "glob": "^7.1.1",
@@ -3122,12 +2911,12 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-ZMLpWynpT9oBYVnvWEhWJ13YYAl4EgMxhEuslNh2nfA2PNdL527zcsoC1qDPgLe3kTvMbFffWu4wTKQy6k9Raw==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-/iS9M0b2a3awSADxV0cAj0EyMl2CsKgQEUT9fbR47sy1de1hZ4pcwTBQ0cESoYmHiDGl8/5uAkCRvN4j4Yjczg==",
       "dependencies": {
-        "@react-native/dev-middleware": "0.79.0-nightly-20250213-9a401c810",
-        "@react-native/metro-babel-transformer": "0.79.0-nightly-20250213-9a401c810",
+        "@react-native/dev-middleware": "0.79.0-nightly-20250218-cda2d11c1",
+        "@react-native/metro-babel-transformer": "0.79.0-nightly-20250218-cda2d11c1",
         "chalk": "^4.0.0",
         "debug": "^2.2.0",
         "invariant": "^2.2.4",
@@ -3174,20 +2963,20 @@
       }
     },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-q772UM/h3Kd/PKgC65+N+AkTbR0a8yyysLLnowgkIXIEISPNTKDdkFOIDC0FpKdsGtAXnnAI13qk9xVZZbvpCw==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-4qru27B91FSudMy5ztX9NySMf2DT7/AwTPC1JYd+Co50tYwygVg6apMnB8X+m9+RYMHbySGaa3SfME6sYvjIWw==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-UGAmX4oFUqu7vZJjf1sn2uvROCqfttxIY0bmyeqgZxWYEnaioRD6q8/KeQ3zP4avAkaM+QGPwJRermSxsUbDmg==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-SV4c7ULdhnpsfzLyw4AC7x0H/DBP4ZLIuxHvgJewP6j0E2GYJ6EAvy7jFQ4pa3Zz0XkwkxiL1t+Wzfrpodfi9A==",
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.79.0-nightly-20250213-9a401c810",
+        "@react-native/debugger-frontend": "0.79.0-nightly-20250218-cda2d11c1",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
@@ -3243,14 +3032,14 @@
       }
     },
     "node_modules/@react-native/eslint-config": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/eslint-config/-/eslint-config-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-ry1buA0xrqsMXOSg5LlsNfFEbkfI0b7R7ThraySU8YXCvY2vRC7dbQLMmhKq0/yPK3jnyoYWlBT81L3iccIqAw==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/eslint-config/-/eslint-config-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-d0mV9RfTxOlAia1NyamOxIMdpzqWs2dQyJNffSw5s24KvCeks+u8G8cMDdtJ4QUrczvhTaUrCFBnKuAj2sJaPA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
         "@babel/eslint-parser": "^7.25.1",
-        "@react-native/eslint-plugin": "0.79.0-nightly-20250213-9a401c810",
+        "@react-native/eslint-plugin": "0.79.0-nightly-20250218-cda2d11c1",
         "@typescript-eslint/eslint-plugin": "^7.1.1",
         "@typescript-eslint/parser": "^7.1.1",
         "eslint-config-prettier": "^8.5.0",
@@ -3270,37 +3059,37 @@
       }
     },
     "node_modules/@react-native/eslint-plugin": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/eslint-plugin/-/eslint-plugin-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-LB/Oxgn0ZWtJV+k2LCf2ajcD72xDcLbTysgwIITGIu17ip+DDjG1dI5oSj7xI6fTgMM4f0NWtRy11CnrFm0WNg==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/eslint-plugin/-/eslint-plugin-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-C3Rg2Jv9uAZbKMxR5tbD5Tu6EcYgn92zbCLr4mEbBD4EVecBw7WBSN0QzsaILQfCDqoKxtPwtSFSYofztifx4g==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-NizN1HV9wtmN39H4w6y8vFxIxvSH/F0ZDoeTD62faPqOY4e3gJbP+AyI90y3H0B3RoflmbOXUM6Fgur6bQvF9A==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-KE2SySjoxfZaY5V+imty1SrTEZU92XEgFER55jKp3/s0m9ZWuPTJTgWN+M99vzvszxcrW2u6+onaWwWLKKfzuQ==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-UgKmqCvxwoYZnzV5YHhF7824AHo/EfmHJ5R9JqCBPFoPFxdMWgPkxkfUgUHwLS3pble10OLvQmKKw3ijd+onQA==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-zzgj7KUsWapYmcaVE7ARbcYotAashWw7kc9PW7oqUDXbcKrudixP3Z0igaLT0r88Be9gi6QlS7uH8YAt/ZP9VQ==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/metro-babel-transformer": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-qaBbtBR+Bz+huLsP4XtzxXL/8+3yIK7kKIZsx69Tjg/ednKWcOv4wMCcyPgc/08Q6m+xWsECJGhXQcXOifrkbQ==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-EGWYoSc6ge4p+MNP6oSubahQ3FtRJJBqdRa9rmkP+yqRhsmyut/LtBO1xa9XwvTBNghlvoiv6yLLl+oQs22z+A==",
       "dependencies": {
         "@babel/core": "^7.25.2",
-        "@react-native/babel-preset": "0.79.0-nightly-20250213-9a401c810",
+        "@react-native/babel-preset": "0.79.0-nightly-20250218-cda2d11c1",
         "hermes-parser": "0.25.1",
         "nullthrows": "^1.1.1"
       },
@@ -3312,13 +3101,13 @@
       }
     },
     "node_modules/@react-native/metro-config": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/metro-config/-/metro-config-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-SQbbs5OVtwhcaRd1oCberGmzQNIr5e/GnIfz9OipJY88M/LQGhF9igfgyBe+3VypgpcuBStRTJT0q2Hd3o6sow==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/metro-config/-/metro-config-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-rQI1hdHMC2VI317Kh228NZK7WUZ7rdACqO6ytLXe0uyCed08ebRyDMvKOd00jgNZzaU7ilVKUpV2pLD+p/Uo4g==",
       "dev": true,
       "dependencies": {
-        "@react-native/js-polyfills": "0.79.0-nightly-20250213-9a401c810",
-        "@react-native/metro-babel-transformer": "0.79.0-nightly-20250213-9a401c810",
+        "@react-native/js-polyfills": "0.79.0-nightly-20250218-cda2d11c1",
+        "@react-native/metro-babel-transformer": "0.79.0-nightly-20250218-cda2d11c1",
         "metro-config": "^0.81.0",
         "metro-runtime": "^0.81.0"
       },
@@ -3327,20 +3116,20 @@
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-Wbv8WqVKDcy629oy1Rtw21ZjuyNNp3lf4n642hqJlKWQU6P7fWbMIZmuT/F+TLdU9kucG6wIVXElAfZy7paxYA=="
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-UpV8dM9kA7ehcQXAgudaWLK/Gfq0rq0F16tXZjNkCgFRrYtAHCsdmoOfGveqZ0NlpNJG70dyCjZ8HY6bb8/S9Q=="
     },
     "node_modules/@react-native/typescript-config": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/typescript-config/-/typescript-config-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-Lw/xbXlJyUj0DhE5Dw+2cpQqBGXVacQ1pYtQRRD6tz5D9VX3gVSMKos1COEW16lxcPxocJQaTw8crXPoicxFgA==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/typescript-config/-/typescript-config-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-83B0qqSCwa+YuANZJIfvqwrahNg/Yx7lwZC5QDKfmX5QDGq8gzdWFab/feuj2L/CdA807tqiUgLuXtUu3pLmFw==",
       "dev": true
     },
     "node_modules/@react-native/virtualized-lists": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-1fG7IAIGnHgm/0AUKiSJ1HO3E/dDOmg+McZ38v6cTjcpV4m/lscuWU5tVN0hYQEBHJD0Agjc551xav8TBdxF6g==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-IUFoqY3Nkx7t7FJemTYUzkMcKgy8FgBShuKj2A9uqr+x1nSFHBcekBgsDBYVkIpS6ZT2o975IhXB0M5kTwMY/g==",
       "dependencies": {
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1"
@@ -3516,9 +3305,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
-      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
+      "version": "22.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
+      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -3532,9 +3321,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.0.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
-      "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
+      "version": "19.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
+      "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
       "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4202,12 +3991,12 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
-      "integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
+      "integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.2",
-        "core-js-compat": "^3.38.0"
+        "@babel/helper-define-polyfill-provider": "^0.6.3",
+        "core-js-compat": "^3.40.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -4431,9 +4220,9 @@
       }
     },
     "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4507,9 +4296,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001698",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001698.tgz",
-      "integrity": "sha512-xJ3km2oiG/MbNU8G6zIq6XRZ6HtAOVXsbOrP/blGazi52kc5Yy7b6sDA5O+FbROzRrV7BSTllLHuNvmawYUJjw==",
+      "version": "1.0.30001700",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
+      "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4762,9 +4551,9 @@
       }
     },
     "node_modules/compression": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.5.tgz",
-      "integrity": "sha512-bQJ0YRck5ak3LgtnpKkiabX5pNF7tMUh1BSy2ZBOTh0Dim0BUu6aPPwByIns6/A5Prh8PufSPerMDUklpzes2Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
+      "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
       "devOptional": true,
       "dependencies": {
         "bytes": "3.1.2",
@@ -5146,9 +4935,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.95",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.95.tgz",
-      "integrity": "sha512-XNsZaQrgQX+BG37BRQv+E+HcOZlWhqYaDoVVNCws/WrYYdbGrkR1qCDJ2mviBF3flCs6/BTa4O7ANfFTFZk6Dg=="
+      "version": "1.5.102",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.102.tgz",
+      "integrity": "sha512-eHhqaja8tE/FNpIiBrvBjFV/SSKpyWHLvxuR9dPTdo+3V9ppdLmFB7ZZQ98qNovcngPLYIz0oOBF9P0FfZef5Q=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -5363,12 +5152,15 @@
       }
     },
     "node_modules/es-shim-unscopables": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
-      "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
       "dev": true,
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-to-primitive": {
@@ -6104,18 +5896,14 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.1.tgz",
-      "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.2.tgz",
+      "integrity": "sha512-xmnYV9o0StIz/0ArdzmWTxn9oDy0lH8Z80/8X/TD2EUQKXY4DHxoT9mYBqgGIG17DgddCJtH1M6DriMbalNsAA==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "dependencies": {
@@ -6326,9 +6114,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
     },
     "node_modules/flow-enums-runtime": {
@@ -6337,17 +6125,17 @@
       "integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw=="
     },
     "node_modules/flow-parser": {
-      "version": "0.261.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.261.0.tgz",
-      "integrity": "sha512-b6ffusIxt5dX8QmX6+QCUi8NrbzNZ0C+ynDC8vbe8KbZ7chJjnYGr5ssiiPR2b51vdqUHPay1HB5AhRp6CDc4Q==",
+      "version": "0.261.1",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.261.1.tgz",
+      "integrity": "sha512-2l5bBKeVtT+d+1CYSsTLJ+iP2FuoR7zjbDQI/v6dDRiBpx3Lb20Z/tLS37ReX/lcodyGSHC2eA/Nk63hB+mkYg==",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/for-each": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.4.tgz",
-      "integrity": "sha512-kKaIINnFpzW6ffJNDjjyjrk21BkDx38c0xa/klsT8VzLCaMEefv4ZTacrcVR4DmgTeBra++jMDAfS/tS799YDw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -10080,18 +9868,18 @@
       "devOptional": true
     },
     "node_modules/react-native": {
-      "version": "0.79.0-nightly-20250213-9a401c810",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.0-nightly-20250213-9a401c810.tgz",
-      "integrity": "sha512-jgsoFPLnUBkLS5ElNphY8u+gqeRuviim0ihqiWbLNfwyyi62GByAbOffvUF53Khi1KD4kVwCYPtN9iYCiFOxOQ==",
+      "version": "0.79.0-nightly-20250218-cda2d11c1",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.0-nightly-20250218-cda2d11c1.tgz",
+      "integrity": "sha512-9qBcELyEx3CPqVrI73rdKbKqughbOJHao42FmCaiCtGMfWH/z0Xr/VQa44VCFe8OZFkRHeS/VsbDhPRvPoPEjA==",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
-        "@react-native/assets-registry": "0.79.0-nightly-20250213-9a401c810",
-        "@react-native/codegen": "0.79.0-nightly-20250213-9a401c810",
-        "@react-native/community-cli-plugin": "0.79.0-nightly-20250213-9a401c810",
-        "@react-native/gradle-plugin": "0.79.0-nightly-20250213-9a401c810",
-        "@react-native/js-polyfills": "0.79.0-nightly-20250213-9a401c810",
-        "@react-native/normalize-colors": "0.79.0-nightly-20250213-9a401c810",
-        "@react-native/virtualized-lists": "0.79.0-nightly-20250213-9a401c810",
+        "@react-native/assets-registry": "0.79.0-nightly-20250218-cda2d11c1",
+        "@react-native/codegen": "0.79.0-nightly-20250218-cda2d11c1",
+        "@react-native/community-cli-plugin": "0.79.0-nightly-20250218-cda2d11c1",
+        "@react-native/gradle-plugin": "0.79.0-nightly-20250218-cda2d11c1",
+        "@react-native/js-polyfills": "0.79.0-nightly-20250218-cda2d11c1",
+        "@react-native/normalize-colors": "0.79.0-nightly-20250218-cda2d11c1",
+        "@react-native/virtualized-lists": "0.79.0-nightly-20250218-cda2d11c1",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
@@ -10971,9 +10759,9 @@
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
     "node_modules/stacktrace-parser": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz",
-      "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+      "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
       "dependencies": {
         "type-fest": "^0.7.1"
       },
@@ -11249,9 +11037,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.38.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.38.1.tgz",
-      "integrity": "sha512-GWANVlPM/ZfYzuPHjq0nxT+EbOEDDN3Jwhwdg1D8TU8oSkktp8w64Uq4auuGLxFSoNTRDncTq2hQHX1Ld9KHkA==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
+      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",

--- a/ios/RCTJscInstance.h
+++ b/ios/RCTJscInstance.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <cxxreact/MessageQueueThread.h>
+#import <jsi/jsi.h>
+#import <react/runtime/JSRuntimeFactory.h>
+
+namespace facebook {
+namespace react {
+
+class RCTJscInstance : public JSRuntimeFactory {
+ public:
+  RCTJscInstance();
+
+  std::unique_ptr<JSRuntime> createJSRuntime(
+      std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept override;
+
+  ~RCTJscInstance(){};
+};
+} // namespace react
+} // namespace facebook

--- a/ios/RCTJscInstance.mm
+++ b/ios/RCTJscInstance.mm
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTJscInstance.h"
+#include "JSCRuntime.h"
+
+namespace facebook {
+namespace react {
+
+RCTJscInstance::RCTJscInstance() {}
+
+std::unique_ptr<JSRuntime> RCTJscInstance::createJSRuntime(std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept
+{
+  return std::make_unique<JSIRuntimeHolder>(jsc::makeJSCRuntime());
+}
+
+} // namespace react
+} // namespace facebook


### PR DESCRIPTION
This PR uses `JSITooling` package + sets ENV to skip linking internal JSC. We are now only missing an API that would allow changing runtime switching from Swift/Obj-C (https://github.com/facebook/react-native/pull/49489).

![CleanShot 2025-02-18 at 16 45 46@2x](https://github.com/user-attachments/assets/5e5627eb-5dac-49ce-951d-454bbfda9a07)
