### PR TITLE
feat: add a runtime config for debugger options

### DIFF
--- a/common/JSCRuntime.h
+++ b/common/JSCRuntime.h
@@ -15,7 +15,14 @@
 namespace facebook {
 namespace jsc {
 
+struct RuntimeConfig {
+  bool enableDebugger;
+  std::string debuggerName;
+};
+
 std::unique_ptr<jsi::Runtime> makeJSCRuntime();
+
+std::unique_ptr<jsi::Runtime> makeJSCRuntime(const facebook::jsc::RuntimeConfig& rc);
 
 } // namespace jsc
 } // namespace facebook

--- a/ios/RCTJscInstance.h
+++ b/ios/RCTJscInstance.h
@@ -18,10 +18,22 @@ class RCTJscInstance : public JSRuntimeFactory {
  public:
   RCTJscInstance();
 
+  void setEnableDebugger(bool enableDebugger);
+
+  void setDebuggerName(const std::string &debuggerName);
+
   std::unique_ptr<JSRuntime> createJSRuntime(
       std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept override;
 
   ~RCTJscInstance(){};
+
+  private:
+#if DEBUG
+  bool enableDebugger_ = true;
+#else
+  bool enableDebugger_ = false;
+#endif
+  std::string debuggerName_ = "JSC React Native";
 };
 } // namespace react
 } // namespace facebook

--- a/ios/RCTJscInstance.mm
+++ b/ios/RCTJscInstance.mm
@@ -13,11 +13,11 @@ namespace react {
 
 RCTJscInstance::RCTJscInstance() {}
 
-void JSCExecutorFactory::setEnableDebugger(bool enableDebugger) {
+void RCTJscInstance::setEnableDebugger(bool enableDebugger) {
   enableDebugger_ = enableDebugger;
 }
 
-void JSCExecutorFactory::setDebuggerName(const std::string &debuggerName) {
+void RCTJscInstance::setDebuggerName(const std::string &debuggerName) {
   debuggerName_ = debuggerName;
 }
 

--- a/ios/RCTJscInstance.mm
+++ b/ios/RCTJscInstance.mm
@@ -13,9 +13,21 @@ namespace react {
 
 RCTJscInstance::RCTJscInstance() {}
 
+void JSCExecutorFactory::setEnableDebugger(bool enableDebugger) {
+  enableDebugger_ = enableDebugger;
+}
+
+void JSCExecutorFactory::setDebuggerName(const std::string &debuggerName) {
+  debuggerName_ = debuggerName;
+}
+
 std::unique_ptr<JSRuntime> RCTJscInstance::createJSRuntime(std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept
 {
-  return std::make_unique<JSIRuntimeHolder>(jsc::makeJSCRuntime());
+  jsc::RuntimeConfig rc = {
+    .enableDebugger = enableDebugger_,
+    .debuggerName = debuggerName_,
+  };
+  return std::make_unique<JSIRuntimeHolder>(jsc::makeJSCRuntime(std::move(rc)));
 }
 
 } // namespace react


### PR DESCRIPTION
See https://github.com/facebook/react-native/pull/38942 for context.

This PR is a port of a PR I made to React Native macOS, that never made it to React Native Core. It adds a runtimeConfig to the JSC instance (similar to what Hermes has) so we can enable/disable debugging and set a target name. This is particularly useful when there are multiple JSC instances you could debug. 

I'm not sure how to test this, since the code here is slightly different than what was in React Native / React Native macOS, and I mostly just copy/pasted my changes. 