### PR TITLE
fix missed imports for Android in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Open `MainApplication.java` and overwrite `getJavaScriptExecutorFactory` method:
 ```diff
 +import io.github.reactnativecommunity.javascriptcore.JSCExecutorFactory
 +import io.github.reactnativecommunity.javascriptcore.JSCRuntimeFactory
++import com.facebook.react.bridge.JavaScriptExecutorFactory
++import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 
 class MainApplication : Application(), ReactApplication {
 


### PR DESCRIPTION
After installing this package and building for Android, I am encountering the following errors:

```
Unresolved reference 'JavaScriptExecutorFactory'.
Unresolved reference 'AndroidInfoHelpers'. 
```

<img width="1471" alt="image" src="https://github.com/user-attachments/assets/7f78347d-a856-4357-afb2-823bc001025a" />
