### PR TITLE
fix: change `JSRuntimeFactory` to `JSRuntimeFactoryRef` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
     #endif
   }
 
-+  override func createJSRuntimeFactory() -> JSRuntimeFactory {
++  override func createJSRuntimeFactory() -> JSRuntimeFactoryRef {
 +    jsrt_create_jsc_factory() // Use JavaScriptCore runtime
 +  }
 }


### PR DESCRIPTION
# Summary

This PR changes `JSRuntimeFactory` to `JSRuntimeFactoryRef` in README, so it matches example 