### PR TITLE
chore: add missing return to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
   }
 
 +  override func createJSRuntimeFactory() -> JSRuntimeFactoryRef {
-+    jsrt_create_jsc_factory() // Use JavaScriptCore runtime
++    return jsrt_create_jsc_factory() // Use JavaScriptCore runtime
 +  }
 }
 ```


### PR DESCRIPTION
# Summary

Adds missing return to iOS README so it matches example